### PR TITLE
Add secure discovery mode, parse discovery details from YAML

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
     "image": "mcr.microsoft.com/devcontainers/go",
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
     "customizations": {
         "vscode": {
             "extensions": [
@@ -11,4 +14,3 @@
     },
     "postCreateCommand": "go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest"
 }
-

--- a/deploy/exampleConfiguration.yaml
+++ b/deploy/exampleConfiguration.yaml
@@ -13,10 +13,11 @@ custom:
     name: http-range-switch # The name of akric
     capacity: 2
     discoveryHandlerName: http-discovery-switch # name of discovery handler, must be unique and matching discovery.name. will be used for socket creation
-    discoveryDetails: |
+    discoveryDetails: | # make sure this is valid YAML
       ipStart: 192.168.11.36
       ipEnd: 192.168.11.45
       applicationType: fmnist
+      secure: true
     brokerPod:
       image:
         repository: gntouts/akri-example-broker

--- a/discovery.go
+++ b/discovery.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/smirzaei/parallel"
+	"gopkg.in/yaml.v3"
 )
 
 type Device struct {
@@ -25,35 +25,29 @@ type DiscoveredDevices struct {
 }
 
 type DiscoveryDetails struct {
-	IPStart     string
-	IPEnd       string
-	Application string
+	IPStart     string `yaml:"ipStart"`
+	IPEnd       string `yaml:"ipEnd"`
+	Application string `yaml:"applicationType"`
+	Secure      bool   `yaml:"secure"`
+}
+
+func (d *DiscoveryDetails) UnmarshalYAML(value *yaml.Node) error {
+	type rawDetails DiscoveryDetails
+	raw := rawDetails{
+		Secure: true, // Set default value if secure is not provided
+	}
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*d = DiscoveryDetails(raw)
+	return nil
 }
 
 func NewDiscoveryDetails(input string) (DiscoveryDetails, error) {
-	details := DiscoveryDetails{}
-	lines := strings.Split(input, "\n")
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-		parts := strings.SplitN(line, ": ", 2)
-		if len(parts) != 2 {
-			return details, errors.New("invalid input format")
-		}
-		switch parts[0] {
-		case "ipStart":
-			details.IPStart = parts[1]
-		case "ipEnd":
-			details.IPEnd = parts[1]
-		case "applicationType":
-			details.Application = parts[1]
-		default:
-			return details, errors.New("unknown field in input")
-		}
-	}
-	if details.IPStart == "" || details.IPEnd == "" || details.Application == "" {
-		return details, errors.New("missing fields in input")
+	var details DiscoveryDetails
+	err := yaml.Unmarshal([]byte(input), &details)
+	if err != nil {
+		return details, err
 	}
 	return details, nil
 }
@@ -94,7 +88,7 @@ func (details DiscoveryDetails) Scan() ([]Device, error) {
 	}
 
 	resultIPs := parallel.MapLimit(ipAddresses, maxConcurrency, func(ip string) Device {
-		res := scanDevice(ip, details.Application)
+		res := scanDevice(ip, details.Application, details.Secure)
 		return res
 	})
 	successIPs := []Device{}
@@ -113,7 +107,7 @@ type DeviceInfo struct {
 	Version     string `json:"version"`
 }
 
-func scanDevice(ip string, expected string) Device {
+func scanDevice(ip string, expected string, secure bool) Device {
 	dev := Device{
 		Hostname:   ip,
 		Discovered: false,
@@ -144,10 +138,22 @@ func scanDevice(ip string, expected string) Device {
 		// fmt.Printf("Error parsing JSON from %s: %v\n", url, err)
 		return dev
 	}
-	if deviceInfo.Application == expected {
-		fmt.Printf("Discovered device %s with type %s\n", ip, deviceInfo.Application)
+	if deviceInfo.Application != expected {
+		return dev
+	}
+
+	if secure {
+		trusted := VerifyDevice(ip)
+		if !trusted {
+			fmt.Printf("Device %s is not trusted\n", ip)
+			return dev
+		}
 		dev.Discovered = true
 		dev.Info = deviceInfo // Store the parsed information
+		return dev
 	}
+
+	dev.Discovered = true
+	dev.Info = deviceInfo // Store the parsed information
 	return dev
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/smirzaei/parallel v1.1.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/protobuf v1.33.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,7 @@ google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/verification.go
+++ b/verification.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func GetDerData(endpoint string) ([]byte, error) {
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("bad status code: %d", resp.StatusCode)
+		return nil, err
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func DerToPem(derBytes []byte) ([]byte, error) {
+	// Parse DER bytes
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create PEM block
+	pemBlock := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+
+	// Encode to PEM format
+	return pem.EncodeToMemory(pemBlock), nil
+}
+
+func VerifyCertificate(data []byte, endpoint string) error {
+	postResp, err := http.Post(
+		endpoint,
+		"text/plain",
+		bytes.NewReader(data),
+	)
+
+	if err != nil {
+		return err
+	}
+	defer postResp.Body.Close()
+
+	_, _ = io.ReadAll(postResp.Body)
+	if postResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status code: %d", postResp.StatusCode)
+	}
+	return nil
+}
+
+func GetAttestationServer() string {
+	tmp := os.Getenv("DICE_AUTH_SERVICE_PORT")
+	return strings.ReplaceAll(tmp, "tcp", "http")
+}
+
+func VerifyDevice(ip string) bool {
+	endpoint := fmt.Sprintf("http://%s/oboard", ip)
+	derData, err := GetDerData(endpoint)
+	if err != nil {
+		return false
+	}
+	pemData, err := DerToPem(derData)
+	if err != nil {
+		return false
+	}
+	attestationServer := GetAttestationServer()
+	if attestationServer == "" {
+		return false
+	}
+	err = VerifyCertificate(pemData, attestationServer)
+	return err == nil
+}


### PR DESCRIPTION
Update DH to check if a device is trusted before returning it as a discovery result. This is done by checking the device's certificate against the Dice Auth server.
Update DH to parse discovery details from YAML for more reliable configuration.
Update discovery details to toggle between secure and insecure discovery (default is secure).